### PR TITLE
Different features in production and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "webpack-dev-server",
-    "build": "webpack"
+    "build": "webpack -p"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "react-dom": "^16.0.0"
   },
   "scripts": {
-    "dev": "webpack-dev-server",
+    "dev": "webpack-dev-server --env.activateSourceMaps",
     "build": "webpack -p"
   },
   "devDependencies": {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,6 +4,7 @@ import { render } from 'react-dom';
 export default class App extends Component {
   dog = () => {
     console.log('hey doggy dog');
+    console.log(process.env.NODE_ENV);
   }
 
   render() {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,7 +4,6 @@ import { render } from 'react-dom';
 export default class App extends Component {
   dog = () => {
     console.log('hey doggy dog');
-    console.log(process.env.NODE_ENV);
   }
 
   render() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,4 +34,4 @@ module.exports = (env = {}) => ({
   resolve: {
     extensions: ['.js', '.jsx'],
   },
-};
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ const paths = {
   js: path.resolve(__dirname, 'src/js'),
 };
 
-module.exports = {
+module.exports = (env = {}) => ({
+  devtool: env.activateSourceMaps ? 'cheap-module-eval-source-map' : undefined,
   entry: path.join(paths.js, 'app.js'),
   output: {
     path: paths.dist,


### PR DESCRIPTION
This is a good starting point for differentiating between development and production features:

- the -p in for the webpack task activates uglify for minification and dead code eliminiation and it sets `process.env.NODE_ENV` to production which activates reacts production mode which makes it a lot faster
- the --env.<flag> flags are taken by webpack and added to the config which can now be a function from env to config. This way we can change things depending on the way the bundle is built. Here we added source maps in the dev task. (open the chrome console and click on the "click for dog" button. There you can see the origin of the console.log, chrome can even open and show this file)